### PR TITLE
Add ability to increase log level for flannel.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,6 +6,7 @@ flanneld_network: "172.42.0.0/16"
 flanneld_backend_type: "host-gw"
 flanneld_img: "quay.io/coreos/flannel"
 flannel_rkt_global_args: ""
+flannel_log_level: 0
 
 docker_service: "docker.service"
 docker_dropin_dir: "/etc/systemd/system/{{docker_service}}.d"

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -3,8 +3,13 @@
   become: yes
   command: systemctl daemon-reload
   notify:
+    - Stop flannel
     - Start flannel
     - Reconfigure docker
+
+- name: Stop flannel
+  become: yes
+  service: name={{flanneld_service}} state=stopped
 
 - name: Start flannel
   become: yes

--- a/templates/10-env.conf
+++ b/templates/10-env.conf
@@ -1,3 +1,4 @@
 [Service]
 Environment="FLANNEL_IMG={{flanneld_img}}"
 Environment="RKT_GLOBAL_ARGS={{flannel_rkt_global_args}}"
+Environment="FLANNEL_OPTS=--ip-masq=true -v={{flannel_log_level}}"


### PR DESCRIPTION
Flannel supports -v flag to set loglevel. 

ip-mask True is passed on by default but since we are overriding the FLANNEL_OPTS we need to also provide this value.