### PR TITLE
FIX: Use a private address block for pod networks

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,7 +2,7 @@
 # defaults file for ansible-flannel
 flanneld_service: "flanneld.service"
 flanneld_dropin_dir: "/etc/systemd/system/{{flanneld_service}}.d"
-flanneld_network: "172.42.0.0/16"
+flanneld_network: "172.24.0.0/16"
 flanneld_backend_type: "host-gw"
 flanneld_img: "quay.io/coreos/flannel"
 flanneld_ver: "v0.9.0"
@@ -11,3 +11,6 @@ flannel_log_level: 0
 
 docker_service: "docker.service"
 docker_dropin_dir: "/etc/systemd/system/{{docker_service}}.d"
+
+# Remove flannel's local subnet config
+remove_local_subnet_config: false

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -4,12 +4,18 @@
   command: systemctl daemon-reload
   notify:
     - Stop flannel
+    - Remove flannel's local subnet config file
     - Start flannel
     - Reconfigure docker
 
 - name: Stop flannel
   become: yes
   service: name={{flanneld_service}} state=stopped
+
+- name: Remove flannel's local subnet config file
+  become: yes
+  file: path=/run/flannel/ state=absent
+  when: remove_local_subnet_config
 
 - name: Start flannel
   become: yes


### PR DESCRIPTION
Also adds a handler to remove flannel's local subnet config files under
/run/flannel. When flanneld's network config is changed and restarted, it fails
to start the first time if the network config doesn't match with the old lease.
Removing the runtime config after changing the network config fixes this issue.