### PR TITLE
Prevent flanneld from starting unless static IP is set

### DIFF
--- a/templates/05-after-static-ip.conf.j2
+++ b/templates/05-after-static-ip.conf.j2
@@ -1,3 +1,3 @@
 [Unit]
-Wants={{static_ip_service}}
+Requires={{static_ip_service}}
 After={{static_ip_service}}


### PR DESCRIPTION
flanneld should not start at all unless static IP is set. When it does, it
obtains a subnet lease based on the DHCP IP address acquired during PXE boot,
which breaks the routes for the pods running on the node.