### PR TITLE
Remove depency on fix-eth0 service to fix a race condition.

### DIFF
--- a/templates/05-after-static-ip.conf.j2
+++ b/templates/05-after-static-ip.conf.j2
@@ -1,9 +1,5 @@
 # Copyright © 2015 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: MIT OR GPL-3.0-only
-[Unit]
-Requires={{static_ip_service}}
-After={{static_ip_service}}
-
 [Service]
 # No DHCP address should be set
 ExecStartPre=/usr/bin/bash -c '[[ ! $(/usr/bin/ip -f inet -br address show eth0 dynamic) ]]'


### PR DESCRIPTION
Remove depency on fix-eth0 service. This dependency causes a race condition where the DHCP IP address gets deleted before the cloud-config can be downloaded. This change will fix the race condition.