### PR TITLE
Remove the code that deletes docker0 bridge to reconfigure docker

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -8,7 +8,7 @@
     - Stop flannel
     - Remove flannel's local subnet config file
     - Start flannel
-    - Reconfigure docker
+    - Restart docker
 
 - name: Stop flannel
   become: yes
@@ -23,16 +23,6 @@
   become: yes
   service: name={{flanneld_service}} state=started enabled=yes
 
-- name: Reconfigure docker
-  command: /bin/true
-  notify:
-    - Stop docker
-    - Start docker
-
-- name: Stop docker
+- name: Restart docker
   become: yes
-  service: name=docker.service state=stopped
-
-- name: Start docker
-  become: yes
-  service: name=docker.service state=started
+  service: name=docker.service state=restarted

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -27,19 +27,11 @@
   command: /bin/true
   notify:
     - Stop docker
-    - Destroy docker0
     - Start docker
 
 - name: Stop docker
   become: yes
   service: name=docker.service state=stopped
-
-- name: Destroy docker0
-  become: yes
-  shell: >
-    ip link set docker0 down &&
-    brctl delbr docker0 ||
-    true
 
 - name: Start docker
   become: yes


### PR DESCRIPTION
Remove the code that deletes docker0 bridge to reconfigure docker. Deleting bridge causes existing veths to be in broken state if docker is running with --live-restore option.